### PR TITLE
Fix loan deletion balance and UI update

### DIFF
--- a/admin/components/transactions/CreditosTab.tsx
+++ b/admin/components/transactions/CreditosTab.tsx
@@ -1312,16 +1312,15 @@ export const CreditosTab = ({ selectedDate, selectedRoute, selectedLead, onBalan
         // ✅ ELIMINADO: Cerrar formulario - ya no aplica con tabla Excel
 
         // 3. Actualizar los datos en segundo plano
-        Promise.all([
+        await Promise.all([
           refetchRoute(),
           refetchLoans()
-        ]).then(() => {
-          // 4. Actualizar el balance local
-          if (onBalanceUpdate) {
-            const totalAmount = parseFloat(data.createLoan.amountGived);
-            onBalanceUpdate(-totalAmount);
-          }
-        });
+        ]);
+        
+        // 4. Llamar al callback para actualizar el RouteLeadSelector
+        if (onBalanceUpdate) {
+          onBalanceUpdate(0); // El valor no importa, solo dispara la actualización
+        }
       }
     } catch (error) {
       console.error('Error al crear el préstamo:', error);
@@ -1490,11 +1489,9 @@ export const CreditosTab = ({ selectedDate, selectedRoute, selectedLead, onBalan
           refetchLoans()
         ]);
 
-        // Actualizar el balance local
+        // Llamar al callback para actualizar el RouteLeadSelector
         if (onBalanceUpdate) {
-          const totalAmount = data.createMultipleLoans.reduce((sum: number, loan: any) =>
-            sum + parseFloat(loan.amountGived || '0'), 0);
-          onBalanceUpdate(-totalAmount);
+          onBalanceUpdate(0); // El valor no importa, solo dispara la actualización
         }
       }
     } catch (error) {
@@ -1602,16 +1599,16 @@ export const CreditosTab = ({ selectedDate, selectedRoute, selectedLead, onBalan
       if (data?.deleteLoan) {
         setLoans(prevLoans => prevLoans.filter(loan => loan.id !== id));
 
-        Promise.all([
+        // Refrescar los datos y esperar a que terminen
+        await Promise.all([
           refetchLoans(),
           refetchRoute()
-        ]).then(() => {
-          if (onBalanceUpdate) {
-            const updatedBalance = routeBalance + parseFloat(data.deleteLoan.amountGived) + parseFloat(data.deleteLoan.comissionAmount || '0');
-            onBalanceUpdate(updatedBalance);
-            setRouteBalance(updatedBalance);
-          }
-        });
+        ]);
+
+        // Llamar al callback para actualizar el RouteLeadSelector
+        if (onBalanceUpdate) {
+          onBalanceUpdate(0); // El valor no importa, solo dispara la actualización
+        }
       }
     } catch (error) {
       console.error('Error al eliminar el préstamo:', error);

--- a/admin/pages/transacciones.tsx
+++ b/admin/pages/transacciones.tsx
@@ -97,6 +97,7 @@ export default function TransaccionesPage() {
   const [selectedLead, setSelectedLead] = useState<EmployeeWithTypename | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [routeSelectorKey, setRouteSelectorKey] = useState(0);
 
   const { data: routesData, loading: routesLoading } = useQuery(GET_ROUTES_SIMPLE, {
     variables: {
@@ -195,6 +196,10 @@ export default function TransaccionesPage() {
             selectedDate={selectedDate}
             selectedRoute={selectedRoute?.id || null}
             selectedLead={toCreditLead(selectedLead)}
+            onBalanceUpdate={() => {
+              // Forzar actualización del RouteLeadSelector
+              setRouteSelectorKey(prev => prev + 1);
+            }}
           />
         );
       case 'payments':
@@ -226,6 +231,7 @@ export default function TransaccionesPage() {
       <Box css={{ padding: '24px' }}>
         <Box css={{ display: 'flex', gap: '16px', marginBottom: '24px' }}>
           <RouteLeadSelector
+            key={routeSelectorKey}
             selectedRoute={selectedRoute}
             selectedLead={selectedLead}
             selectedDate={selectedDate}


### PR DESCRIPTION
Fixes account balance not updating in UI after loan operations by ensuring `RouteLeadSelector` refreshes.

The `CreditosTab` component now correctly awaits data refetches and triggers a re-render of `RouteLeadSelector` via a key prop, ensuring the displayed balance reflects the latest backend state after creating or deleting loans.

---
<a href="https://cursor.com/background-agent?bcId=bc-76c8f667-8f3a-45b6-a54a-55a414adbe1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76c8f667-8f3a-45b6-a54a-55a414adbe1b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

