### PR TITLE
feat: agregar funcionalidad para gestionar cartera muerta en el sistema

### DIFF
--- a/admin/components/CustomNavigation.css
+++ b/admin/components/CustomNavigation.css
@@ -1,0 +1,163 @@
+.menu-section {
+  margin: 0.25rem 0;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  font-weight: 600;
+  color: #495057;
+  font-size: 0.875rem;
+}
+
+.section-header:hover {
+  background: #e9ecef;
+}
+
+.section-header.expanded {
+  background: #dee2e6;
+  border-color: #adb5bd;
+  color: #212529;
+}
+
+.section-title {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  font-size: 0.75rem;
+}
+
+.section-arrow {
+  font-size: 0.875rem;
+  transition: transform 0.15s ease;
+  color: #6c757d;
+  font-weight: bold;
+}
+
+.section-header.expanded .section-arrow {
+  transform: rotate(90deg);
+}
+
+.section-items {
+  margin-top: 0.25rem;
+  padding-left: 1.5rem;
+  border-left: 1px solid #dee2e6;
+}
+
+.section-items a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  color: #495057;
+  text-decoration: none;
+  font-size: 0.875rem;
+  border-radius: 0.25rem;
+  transition: all 0.15s ease;
+  margin: 0.125rem 0;
+}
+
+.section-items a:hover {
+  background: #f8f9fa;
+  color: #212529;
+  padding-left: 1rem;
+}
+
+/* Dashboard destacado */
+.menu-section:first-child a {
+  font-weight: 600;
+  color: #212529;
+  padding: 0.75rem 1rem;
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 0.375rem;
+  margin: 0.5rem 0;
+}
+
+.menu-section:first-child a:hover {
+  background: #e9ecef;
+  border-color: #adb5bd;
+}
+
+/* Estilos para el toggle de listas de Keystone */
+.keystone-lists-toggle {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  color: #495057;
+  text-decoration: none;
+  font-size: 0.875rem;
+  border-radius: 0.25rem;
+  transition: all 0.15s ease;
+  margin: 0.125rem 0;
+  cursor: pointer;
+  background: #e3f2fd;
+  border: 1px solid #bbdefb;
+  color: #1565c0;
+}
+
+.keystone-lists-toggle:hover {
+  background: #bbdefb;
+  border-color: #90caf9;
+  color: #0d47a1;
+}
+
+/* Sección de listas de Keystone */
+.keystone-lists-section {
+  margin: 1rem 0;
+  padding: 1rem;
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.5rem;
+  border-left: 4px solid #007bff;
+}
+
+.keystone-lists-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #dee2e6;
+  font-weight: 600;
+  color: #495057;
+}
+
+.close-keystone-lists {
+  background: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: background-color 0.15s ease;
+}
+
+.close-keystone-lists:hover {
+  background: #c82333;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .section-header {
+    padding: 0.625rem 0.875rem;
+  }
+  
+  .section-items {
+    padding-left: 1rem;
+  }
+  
+  .section-items a {
+    padding: 0.5rem 0.625rem;
+  }
+  
+  .keystone-lists-section {
+    margin: 0.5rem 0;
+    padding: 0.75rem;
+  }
+}

--- a/admin/components/CustomNavigation.tsx
+++ b/admin/components/CustomNavigation.tsx
@@ -1,0 +1,243 @@
+import React, { useState, useEffect } from 'react';
+import { NavigationContainer, NavItem, ListNavItems } from '@keystone-6/core/admin-ui/components';
+import type { NavigationProps } from '@keystone-6/core/admin-ui/components';
+import './CustomNavigation.css';
+
+interface MenuItem {
+  label: string;
+  href: string;
+  roles: string[];
+}
+
+interface MenuSection {
+  title: string;
+  items: MenuItem[];
+  roles: string[];
+}
+
+const menuSections: MenuSection[] = [
+  {
+    title: 'Clientes',
+    roles: ['NORMAL', 'ADMIN'],
+    items: [
+      {
+        label: 'Historial de Clientes',
+        href: '/historial-cliente',
+        roles: ['NORMAL', 'ADMIN']
+      },
+      {
+        label: 'Carga de Documentos',
+        href: '/documentos-personales',
+        roles: ['NORMAL', 'ADMIN']
+      },
+
+    ]
+  },
+  {
+    title: 'Operaciones',
+    roles: ['NORMAL', 'ADMIN'],
+    items: [
+      {
+        label: 'Captura Semanal',
+        href: '/transacciones',
+        roles: ['NORMAL', 'CAPTURA', 'ADMIN']
+      },
+      {
+        label: 'Carga Gastos Toka',
+        href: '/gastos-toka',
+        roles: ['ADMIN']
+      },
+      {
+        label: 'Listados de Rutas',
+        href: '/generar-listados',
+        roles: ['NORMAL', 'ADMIN']
+      }
+    ]
+  },
+  {
+    title: 'Reportes',
+    roles: ['NORMAL', 'ADMIN'],
+    items: [
+      {
+        label: 'Reporte Financiero',
+        href: '/reporte-financiero',
+        roles: ['ADMIN']
+      },
+      {
+        label: 'Reporte de Cobranza',
+        href: '/reporte-cobranza',
+        roles: ['NORMAL', 'ADMIN']
+      },
+      {
+        label: 'Cumpleaños de Líderes',
+        href: '/cumpleanos-lideres',
+        roles: ['NORMAL', 'ADMIN']
+      }
+    ]
+  },
+  {
+    title: 'Administración del Sistema',
+    roles: ['ADMIN'],
+    items: [
+      {
+        label: 'Administrar Rutas',
+        href: '/administrar-rutas',
+        roles: ['ADMIN']
+      },
+      {
+        label: 'Limpieza de Cartera',
+        href: '/limpieza-cartera',
+        roles: ['ADMIN']
+      },
+      {
+        label: 'Cartera Muerta',
+        href: '/cartera-muerta',
+        roles: ['ADMIN']
+      },
+      {
+        label: 'Configuración de Reportes',
+        href: '/configuracion-reportes',
+        roles: ['ADMIN']
+      },
+      {
+        label: 'Usuarios de Telegram',
+        href: '/telegram-users',
+        roles: ['ADMIN']
+      },
+      {
+        label: 'Todas las Listas',
+        href: '/',
+        roles: ['ADMIN']
+      }
+    ]
+  }
+];
+
+export function CustomNavigation({ authenticatedItem, lists }: NavigationProps) {
+  const [userRole, setUserRole] = useState<string>('NORMAL');
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
+  const [showKeystoneLists, setShowKeystoneLists] = useState<boolean>(false);
+
+  useEffect(() => {
+    // Obtener el rol del usuario desde la sesión
+    if (authenticatedItem && 'id' in authenticatedItem) {
+      // Hacer una consulta GraphQL para obtener el rol del usuario
+      const fetchUserRole = async () => {
+        try {
+          // Usar la API de Keystone para obtener el usuario actual
+          const response = await fetch('/api/graphql', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              query: `
+                query GetCurrentUser {
+                  authenticatedItem {
+                    ... on User {
+                      id
+                      role
+                    }
+                  }
+                }
+              `
+            })
+          });
+
+          const result = await response.json();
+          if (result.data?.authenticatedItem?.role) {
+            setUserRole(result.data.authenticatedItem.role);
+          }
+        } catch (error) {
+          console.error('Error fetching user role:', error);
+          // Fallback al rol por defecto
+          setUserRole('NORMAL');
+        }
+      };
+
+      fetchUserRole();
+    }
+  }, [authenticatedItem]);
+
+  // Filtrar secciones según el rol
+  const filteredSections = menuSections.filter(section => 
+    section.roles.includes(userRole)
+  );
+
+  const toggleSection = (sectionTitle: string) => {
+    const newExpanded = new Set(expandedSections);
+    if (newExpanded.has(sectionTitle)) {
+      newExpanded.delete(sectionTitle);
+    } else {
+      newExpanded.add(sectionTitle);
+    }
+    setExpandedSections(newExpanded);
+  };
+
+  const isSectionExpanded = (sectionTitle: string) => expandedSections.has(sectionTitle);
+
+  const handleShowKeystoneLists = () => {
+    setShowKeystoneLists(!showKeystoneLists);
+  };
+
+  return (
+    <NavigationContainer authenticatedItem={authenticatedItem}>
+      {/* Dashboard */}
+      <NavItem href="/">Dashboard</NavItem>
+      
+      {/* Secciones del menú corporativo */}
+      {filteredSections.map((section, sectionIndex) => (
+        <div key={sectionIndex} className="menu-section">
+          {/* Encabezado de la sección */}
+          <div 
+            className={`section-header ${isSectionExpanded(section.title) ? 'expanded' : ''}`}
+            onClick={() => toggleSection(section.title)}
+          >
+            <span className="section-title">{section.title}</span>
+            <span className="section-arrow">›</span>
+          </div>
+          
+          {/* Elementos de la sección */}
+          {isSectionExpanded(section.title) && (
+            <div className="section-items">
+              {section.items
+                .filter(item => item.roles.includes(userRole))
+                .map((item, itemIndex) => (
+                  <div key={itemIndex}>
+                    {item.label === 'Todas las Listas' ? (
+                      <div 
+                        className="keystone-lists-toggle"
+                        onClick={handleShowKeystoneLists}
+                      >
+                        {item.label}
+                      </div>
+                    ) : (
+                      <NavItem href={item.href}>
+                        {item.label}
+                      </NavItem>
+                    )}
+                  </div>
+                ))}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* Mostrar listas nativas de Keystone cuando se solicite */}
+      {showKeystoneLists && userRole === 'ADMIN' && (
+        <div className="keystone-lists-section">
+          <div className="keystone-lists-header">
+            <span>Listas del Sistema</span>
+            <button 
+              className="close-keystone-lists"
+              onClick={() => setShowKeystoneLists(false)}
+            >
+              ✕
+            </button>
+          </div>
+          <ListNavItems lists={lists} />
+        </div>
+      )}
+    </NavigationContainer>
+  );
+}

--- a/admin/config.ts
+++ b/admin/config.ts
@@ -1,7 +1,9 @@
 // /admin/config.ts
 import type { AdminConfig } from '@keystone-6/core/types';
 import { CustomHeader } from './components/CustomHeader';
+import { CustomNavigation } from './components/CustomNavigation';
 
 export const components: AdminConfig['components'] = {
-  Logo: CustomHeader
+  Logo: CustomHeader,
+  Navigation: CustomNavigation
 };

--- a/admin/graphql/queries/dead-debt.ts
+++ b/admin/graphql/queries/dead-debt.ts
@@ -1,0 +1,14 @@
+import { gql } from '@apollo/client';
+
+export const GET_LOANS_FOR_DEAD_DEBT = gql`
+  query GetLoansForDeadDebt($weeksSinceLoan: Int!, $weeksWithoutPayment: Int!) {
+    loansForDeadDebt(weeksSinceLoan: $weeksSinceLoan, weeksWithoutPayment: $weeksWithoutPayment)
+    deadDebtSummary(weeksSinceLoan: $weeksSinceLoan, weeksWithoutPayment: $weeksWithoutPayment)
+  }
+`;
+
+export const MARK_LOANS_DEAD_DEBT = gql`
+  mutation MarkLoansDeadDebt($loanIds: [ID!]!, $deadDebtDate: String!) {
+    markLoansDeadDebt(loanIds: $loanIds, deadDebtDate: $deadDebtDate)
+  }
+`;

--- a/admin/pages/cartera-muerta.tsx
+++ b/admin/pages/cartera-muerta.tsx
@@ -1,0 +1,475 @@
+import React, { useState } from 'react';
+
+interface DeadDebtLoan {
+  id: string;
+  requestedAmount: number;
+  amountGived: number;
+  signDate: string;
+  pendingAmountStored: number;
+  borrower: {
+    fullName: string;
+    clientCode: string;
+  };
+  lead: {
+    fullName: string;
+    locality: {
+      name: string;
+    };
+  };
+  weeksSinceLoan: number;
+  weeksWithoutPayment: number;
+}
+
+interface DeadDebtSummary {
+  locality: string;
+  loanCount: number;
+  totalAmount: number;
+}
+
+export default function CarteraMuertaPage() {
+  const [weeksSinceLoan, setWeeksSinceLoan] = useState(17);
+  const [weeksWithoutPayment, setWeeksWithoutPayment] = useState(4);
+  const [badDebtDate, setBadDebtDate] = useState(new Date().toISOString().split('T')[0]);
+  const [selectedLoans, setSelectedLoans] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [loans, setLoans] = useState<DeadDebtLoan[]>([]);
+  const [summary, setSummary] = useState<DeadDebtSummary[]>([]);
+  const [hasData, setHasData] = useState(false);
+
+  const handleMarkAsDeadDebt = async () => {
+    if (selectedLoans.length === 0) {
+      setError('Selecciona al menos un crédito para marcar como cartera muerta');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      // Hacer mutación GraphQL real a la base de datos
+      const response = await fetch('/api/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: `
+            mutation MarkLoansDeadDebt($loanIds: [ID!]!, $deadDebtDate: String!) {
+              markLoansDeadDebt(loanIds: $loanIds, deadDebtDate: $deadDebtDate)
+            }
+          `,
+          variables: {
+            loanIds: selectedLoans,
+            deadDebtDate: badDebtDate
+          }
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const result = await response.json();
+      
+      if (result.errors) {
+        throw new Error(result.errors[0].message);
+      }
+
+      // Parsear el resultado de la mutación
+      const mutationResult = JSON.parse(result.data.markLoansDeadDebt);
+      
+      console.log(`Marcando como cartera muerta: ${selectedLoans.join(', ')} con fecha ${badDebtDate}`);
+      setSuccess(`${mutationResult.updatedCount || selectedLoans.length} créditos marcados como cartera muerta exitosamente.`);
+      setSelectedLoans([]); // Clear selection after marking
+      
+      // Re-fetch loans to update the list
+      handleUpdate();
+    } catch (err: any) {
+      console.error('Error al marcar créditos:', err);
+      setError(err.message || 'Error al marcar créditos como cartera muerta');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSelectAll = () => {
+    if (selectedLoans.length === 0) {
+      setSelectedLoans(loans.map(loan => loan.id));
+    } else {
+      setSelectedLoans([]);
+    }
+  };
+
+  const handleUpdate = async () => {
+    setIsLoading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      // Hacer consulta GraphQL real a la base de datos
+      const response = await fetch('/api/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: `
+            query GetLoansForDeadDebt($weeksSinceLoan: Int!, $weeksWithoutPayment: Int!) {
+              loansForDeadDebt(weeksSinceLoan: $weeksSinceLoan, weeksWithoutPayment: $weeksWithoutPayment)
+              deadDebtSummary(weeksSinceLoan: $weeksSinceLoan, weeksWithoutPayment: $weeksWithoutPayment)
+            }
+          `,
+          variables: {
+            weeksSinceLoan,
+            weeksWithoutPayment
+          }
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const result = await response.json();
+      
+      if (result.errors) {
+        throw new Error(result.errors[0].message);
+      }
+
+      // Parsear los datos JSON de la respuesta
+      const loansData = JSON.parse(result.data.loansForDeadDebt) as DeadDebtLoan[];
+      const summaryData = JSON.parse(result.data.deadDebtSummary) as DeadDebtSummary[];
+
+      setLoans(loansData);
+      setSummary(summaryData);
+      setHasData(true);
+      setSuccess(`Se encontraron ${loansData.length} créditos elegibles para cartera muerta`);
+    } catch (err: any) {
+      console.error('Error al cargar créditos:', err);
+      setError('Error al cargar los datos: ' + (err.message || 'Error desconocido'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '1200px', margin: '0 auto' }}>
+      <h1 style={{ marginBottom: '2rem', color: '#1a1a1a' }}>Cartera Muerta</h1>
+      
+      {error && (
+        <div style={{ 
+          backgroundColor: '#fee', 
+          border: '1px solid #fcc', 
+          color: '#c33', 
+          padding: '1rem', 
+          borderRadius: '4px', 
+          marginBottom: '1rem' 
+        }}>
+          {error}
+        </div>
+      )}
+      
+      {success && (
+        <div style={{ 
+          backgroundColor: '#efe', 
+          border: '1px solid #cfc', 
+          color: '#3c3', 
+          padding: '1rem', 
+          borderRadius: '4px', 
+          marginBottom: '1rem' 
+        }}>
+          {success}
+        </div>
+      )}
+
+      <div style={{ 
+        backgroundColor: 'white', 
+        border: '1px solid #ddd', 
+        borderRadius: '8px', 
+        padding: '2rem', 
+        marginBottom: '2rem',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+      }}>
+        <h2 style={{ marginBottom: '1.5rem', color: '#333' }}>Configuración</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '1rem', marginBottom: '1rem' }}>
+          <div>
+            <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: '500' }}>
+              Semanas desde el crédito:
+            </label>
+            <input
+              type="number"
+              value={weeksSinceLoan}
+              onChange={(e) => setWeeksSinceLoan(parseInt(e.target.value) || 0)}
+              min="1"
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                border: '1px solid #ddd',
+                borderRadius: '4px',
+                fontSize: '14px'
+              }}
+            />
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: '500' }}>
+              Semanas sin pago:
+            </label>
+            <input
+              type="number"
+              value={weeksWithoutPayment}
+              onChange={(e) => setWeeksWithoutPayment(parseInt(e.target.value) || 0)}
+              min="1"
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                border: '1px solid #ddd',
+                borderRadius: '4px',
+                fontSize: '14px'
+              }}
+            />
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: '500' }}>
+              Fecha de cartera muerta:
+            </label>
+            <input
+              type="date"
+              value={badDebtDate}
+              onChange={(e) => setBadDebtDate(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                border: '1px solid #ddd',
+                borderRadius: '4px',
+                fontSize: '14px'
+              }}
+            />
+          </div>
+        </div>
+        <button
+          onClick={handleUpdate}
+          disabled={isLoading}
+          style={{
+            backgroundColor: isLoading ? '#6c757d' : '#007bff',
+            color: 'white',
+            border: 'none',
+            padding: '0.75rem 1.5rem',
+            borderRadius: '4px',
+            cursor: isLoading ? 'not-allowed' : 'pointer',
+            fontSize: '14px',
+            fontWeight: '500'
+          }}
+        >
+          {isLoading ? 'Cargando...' : 'Actualizar'}
+        </button>
+      </div>
+
+      {hasData && (
+        <>
+          {/* Resumen por localidad */}
+          {summary.length > 0 && (
+            <div style={{ 
+              backgroundColor: 'white', 
+              border: '1px solid #ddd', 
+              borderRadius: '8px', 
+              padding: '2rem',
+              marginBottom: '2rem',
+              boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+            }}>
+              <h2 style={{ marginBottom: '1.5rem', color: '#333' }}>Resumen por Localidad</h2>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '1rem' }}>
+                {summary.map((item, index) => (
+                  <div key={index} style={{ 
+                    padding: '1rem', 
+                    backgroundColor: '#f8f9fa', 
+                    borderRadius: '4px',
+                    border: '1px solid #e9ecef'
+                  }}>
+                    <h3 style={{ margin: '0 0 0.5rem 0', color: '#495057' }}>{item.locality}</h3>
+                    <p style={{ margin: '0 0 0.25rem 0', color: '#6c757d' }}>
+                      <strong>Créditos:</strong> {item.loanCount}
+                    </p>
+                    <p style={{ margin: '0', color: '#6c757d' }}>
+                      <strong>Monto:</strong> ${item.totalAmount.toLocaleString()}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <div style={{ 
+                marginTop: '1rem', 
+                padding: '1rem', 
+                backgroundColor: '#e3f2fd', 
+                borderRadius: '4px',
+                border: '1px solid #bbdefb'
+              }}>
+                <h3 style={{ margin: '0 0 0.5rem 0', color: '#1565c0' }}>Total General</h3>
+                <p style={{ margin: '0 0 0.25rem 0', color: '#0d47a1' }}>
+                  <strong>Total Créditos:</strong> {summary.reduce((sum, item) => sum + item.loanCount, 0)}
+                </p>
+                <p style={{ margin: '0', color: '#0d47a1' }}>
+                  <strong>Monto Total:</strong> ${summary.reduce((sum, item) => sum + item.totalAmount, 0).toLocaleString()}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Lista de créditos */}
+          {loans.length > 0 && (
+            <div style={{ 
+              backgroundColor: 'white', 
+              border: '1px solid #ddd', 
+              borderRadius: '8px', 
+              padding: '2rem',
+              marginBottom: '2rem',
+              boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+            }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
+                <h2 style={{ margin: '0', color: '#333' }}>Créditos Elegibles ({loans.length})</h2>
+                <button
+                  onClick={handleSelectAll}
+                  style={{
+                    backgroundColor: '#28a745',
+                    color: 'white',
+                    border: 'none',
+                    padding: '0.5rem 1rem',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '14px',
+                    fontWeight: '500'
+                  }}
+                >
+                  {selectedLoans.length === 0 ? 'Seleccionar Todos' : 'Deseleccionar Todos'}
+                </button>
+              </div>
+              
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                  <thead>
+                    <tr style={{ backgroundColor: '#f8f9fa' }}>
+                      <th style={{ padding: '0.75rem', textAlign: 'left', border: '1px solid #dee2e6' }}>
+                        <input
+                          type="checkbox"
+                          checked={selectedLoans.length === loans.length && loans.length > 0}
+                          onChange={handleSelectAll}
+                        />
+                      </th>
+                      <th style={{ padding: '0.75rem', textAlign: 'left', border: '1px solid #dee2e6' }}>Cliente</th>
+                      <th style={{ padding: '0.75rem', textAlign: 'left', border: '1px solid #dee2e6' }}>Líder</th>
+                      <th style={{ padding: '0.75rem', textAlign: 'left', border: '1px solid #dee2e6' }}>Localidad</th>
+                      <th style={{ padding: '0.75rem', textAlign: 'right', border: '1px solid #dee2e6' }}>Monto Pendiente</th>
+                      <th style={{ padding: '0.75rem', textAlign: 'center', border: '1px solid #dee2e6' }}>Semanas Crédito</th>
+                      <th style={{ padding: '0.75rem', textAlign: 'center', border: '1px solid #dee2e6' }}>Sin Pago</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {loans.map((loan) => (
+                      <tr key={loan.id} style={{ borderBottom: '1px solid #dee2e6' }}>
+                        <td style={{ padding: '0.75rem', border: '1px solid #dee2e6' }}>
+                          <input
+                            type="checkbox"
+                            checked={selectedLoans.includes(loan.id)}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setSelectedLoans([...selectedLoans, loan.id]);
+                              } else {
+                                setSelectedLoans(selectedLoans.filter(id => id !== loan.id));
+                              }
+                            }}
+                          />
+                        </td>
+                        <td style={{ padding: '0.75rem', border: '1px solid #dee2e6' }}>
+                          <div>
+                            <div style={{ fontWeight: '500' }}>{loan.borrower.fullName}</div>
+                            <div style={{ fontSize: '0.875rem', color: '#6c757d' }}>{loan.borrower.clientCode}</div>
+                          </div>
+                        </td>
+                        <td style={{ padding: '0.75rem', border: '1px solid #dee2e6' }}>{loan.lead.fullName}</td>
+                        <td style={{ padding: '0.75rem', border: '1px solid #dee2e6' }}>{loan.lead.locality.name}</td>
+                        <td style={{ padding: '0.75rem', textAlign: 'right', border: '1px solid #dee2e6' }}>
+                          ${loan.pendingAmountStored.toLocaleString()}
+                        </td>
+                        <td style={{ padding: '0.75rem', textAlign: 'center', border: '1px solid #dee2e6' }}>
+                          {loan.weeksSinceLoan}
+                        </td>
+                        <td style={{ padding: '0.75rem', textAlign: 'center', border: '1px solid #dee2e6' }}>
+                          {loan.weeksWithoutPayment}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Botones de acción */}
+          {loans.length > 0 && (
+            <div style={{ 
+              backgroundColor: 'white', 
+              border: '1px solid #ddd', 
+              borderRadius: '8px', 
+              padding: '2rem',
+              boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+            }}>
+              <h2 style={{ marginBottom: '1.5rem', color: '#333' }}>Acciones</h2>
+              <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+                <button
+                  onClick={handleMarkAsDeadDebt}
+                  disabled={isLoading || selectedLoans.length === 0}
+                  style={{
+                    backgroundColor: (isLoading || selectedLoans.length === 0) ? '#6c757d' : '#dc3545',
+                    color: 'white',
+                    border: 'none',
+                    padding: '0.75rem 1.5rem',
+                    borderRadius: '4px',
+                    cursor: (isLoading || selectedLoans.length === 0) ? 'not-allowed' : 'pointer',
+                    fontSize: '14px',
+                    fontWeight: '500'
+                  }}
+                >
+                  {isLoading ? 'Procesando...' : `Marcar ${selectedLoans.length} como Cartera Muerta`}
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {!hasData && (
+        <div style={{ 
+          backgroundColor: 'white', 
+          border: '1px solid #ddd', 
+          borderRadius: '8px', 
+          padding: '2rem',
+          boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+        }}>
+          <h2 style={{ marginBottom: '1.5rem', color: '#333' }}>Instrucciones</h2>
+          <p style={{ marginBottom: '1rem', color: '#666' }}>
+            Configura los criterios y haz clic en "Actualizar" para buscar créditos elegibles para cartera muerta.
+          </p>
+          <ul style={{ marginBottom: '1.5rem', color: '#666', paddingLeft: '1.5rem' }}>
+            <li><strong>Semanas desde el crédito:</strong> Mínimo de semanas transcurridas desde que se otorgó el crédito</li>
+            <li><strong>Semanas sin pago:</strong> Mínimo de semanas sin realizar pagos</li>
+            <li><strong>Fecha de cartera muerta:</strong> Fecha que se asignará al marcar como cartera muerta</li>
+          </ul>
+          
+          <div style={{ 
+            backgroundColor: '#f8f9fa', 
+            border: '1px solid #e9ecef', 
+            borderRadius: '4px', 
+            padding: '1rem',
+            marginBottom: '1rem'
+          }}>
+            <h3 style={{ marginBottom: '0.5rem', color: '#495057' }}>Criterios Actuales:</h3>
+            <p style={{ margin: '0', color: '#6c757d' }}>
+              Créditos con más de {weeksSinceLoan} semanas desde el crédito y {weeksWithoutPayment} semanas sin pago
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -2809,6 +2809,7 @@ type Mutation {
   updateLoanWithAval(where: ID!, data: UpdateLoanWithAvalInput): JSON!
   sendTestTelegramMessage(chatId: String!, message: String!): String!
   sendReportWithPDF(chatId: String!, reportType: String!): String!
+  markLoansDeadDebt(loanIds: [ID!]!, deadDebtDate: String!): String!
 }
 
 input TokaAssignmentInput {
@@ -2998,6 +2999,8 @@ type Query {
   previewBulkPortfolioCleanup(routeId: String!, fromDate: String!, toDate: String!, weeksWithoutPaymentThreshold: Int): JSON!
   debugTelegram: String!
   telegramStatus: String!
+  loansForDeadDebt(weeksSinceLoan: Int!, weeksWithoutPayment: Int!): String!
+  deadDebtSummary(weeksSinceLoan: Int!, weeksWithoutPayment: Int!): String!
 }
 
 type LeaderBirthday {


### PR DESCRIPTION
- Se implementaron nuevas mutaciones y consultas GraphQL para marcar préstamos como cartera muerta y obtener un resumen de estos préstamos.
- Se añadió una nueva página en la interfaz de administración para gestionar la cartera muerta, permitiendo a los usuarios seleccionar préstamos y marcarlos con una fecha específica.
- Se mejoró la lógica de consulta para filtrar préstamos elegibles basándose en semanas desde el crédito y semanas sin pago, optimizando la gestión de deudas.
- Se incorporaron estilos y componentes personalizados para mejorar la experiencia del usuario en la nueva funcionalidad.