### PR TITLE
feat: añadir consulta previewBulkPortfolioCleanup al esquema GraphQL

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2983,6 +2983,7 @@ type Query {
   telegramUsersCount(where: TelegramUserWhereInput! = {}): Int
   keystone: KeystoneMeta!
   authenticatedItem: AuthenticatedItem
+  previewBulkPortfolioCleanup(routeId: String!, fromDate: String!, toDate: String!, weeksWithoutPaymentThreshold: Int): JSON!
   getLeadersBirthdays(month: Int!): [LeaderBirthday!]!
   getTransactionsSummary(startDate: String!, endDate: String!, routeId: String): [TransactionSummary!]!
   getMonthlyResume(routeId: String!, year: Int!): JSON!


### PR DESCRIPTION
- Se implementó la nueva consulta `previewBulkPortfolioCleanup` que permite previsualizar la limpieza masiva de cartera, filtrando préstamos activos por fecha de firma y aplicando un umbral de semanas sin pago.
- Se añadió la lógica para calcular el total de préstamos a excluir y se devuelve un resumen con ejemplos de los préstamos afectados.
- Se actualizó el esquema GraphQL para incluir los nuevos argumentos requeridos por la consulta.